### PR TITLE
Multiple markers show on map & fixed package.json for version

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -7,7 +7,7 @@
     "@material-ui/icons": "^1.1.0",
     "axios": "^0.18.0",
     "classnames": "^2.2.6",
-    "google-map-react": "^1.0.4",
+    "google-map-react": "1.0.4",
     "prop-types": "^15.6.2",
     "react": "^16.4.1",
     "react-dom": "^16.4.1",

--- a/client/src/components/TripCreate/Map.jsx
+++ b/client/src/components/TripCreate/Map.jsx
@@ -58,11 +58,22 @@ class Map extends React.Component {
             this.addMarker(event);
           }}
         >
-          <Marker
+          {this.state.markers.map((markers, i) => {
+            return (
+              <Marker
+                key={i}
+                lat={markers.lat}
+                lng={markers.lng}
+              >
+                {markers.lat}, {markers.lng}
+              </Marker>
+            );
+          })}
+          {/* <Marker
             lat={this.state.lat}
             lng={this.state.lng}
             text={this.state.text}
-          />
+          /> */}
         </GoogleMapReact>
         {this.state.markers.map((markers, i) => {
           return (


### PR DESCRIPTION
# Description

Changed the package.json so it will  only download the non bugged version of google-map-react(1.0.4) and not the latest version with the marker bug (1.0.5). Also mapped over the markers to add more than one marker on the map.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)


## Change status

- [x] Complete, tested, ready to review and merge

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] tested by running the local version of the server and front-end. went to create a trip to add markers and it adds multiple markers where they should be when clicking

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My code has been reviewed by at least one peer
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts
