### PR TITLE
User exists vs incorrect password

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,3 +166,6 @@ _______
 * GET `/:user/getArchivedTrips`
 (need to pass in Auth token from login)
 _______
+
+
+<a rel="license" href="http://creativecommons.org/licenses/by/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by/4.0/88x31.png" /></a><br />All images are licensed under a <a rel="license" href="http://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>.

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -23,9 +23,10 @@ class App extends Component {
       validatePassword: '',
       isLoggedIn: false,
       snackbarOpenSignIn: false,
-      snackbarOpenError: false,
+      snackbarPasswordMismatch: false,
       snackbarOpenSignUp: false,
       snackbarOpenSignUpError: false,
+      snackbarUserDoesNotExist: false,
       snackbarLogOut: false,
       snackbarVertical: 'top',
       snackbarHorizontal: 'center',
@@ -54,8 +55,13 @@ class App extends Component {
         console.log(res.data);
       })
       .catch(error => {
-        this.setState({ snackbarOpenError: true });
-        console.log('INCORRECT USERNAME/PASSWORD');
+        if(error.response.status === 423) {
+          console.log('User does not exist')
+          this.setState({ snackbarUserDoesNotExist: true})
+        } else if (error.response.status === 422) {
+          console.log('Password does not match')
+          this.setState({ snackbarPasswordMismatch: true });
+        }
       });
   };
 
@@ -94,10 +100,11 @@ class App extends Component {
       return;
     }
     this.setState({ snackbarOpenSignIn: false });
-    this.setState({ snackbarOpenError: false });
+    this.setState({ snackbarPasswordMismatch: false });
     this.setState({ snackbarOpenSignUp: false });
     this.setState({ snackbarOpenSignUpError: false });
     this.setState({ snackbarLogOut: false });
+    this.setState({ snackbarUserDoesNotExist: false });
   };
   handleTabChange = (event, value) => {
     this.setState({ tabState: value });
@@ -112,13 +119,14 @@ class App extends Component {
           <React.Fragment>
             <MainSnackbar
               snackbarOpenSignIn={this.state.snackbarOpenSignIn}
-              snackbarOpenError={this.state.snackbarOpenError}
+              snackbarPasswordMismatch={this.state.snackbarPasswordMismatch}
               snackbarOpenSignUp={this.state.snackbarOpenSignUp}
               snackbarOpenSignUpError={this.state.snackbarOpenSignUpError}
               snackbarLogOut={this.state.snackbarLogOut}
               handleSnackbarClose={this.handleSnackbarClose}
               snackbarVertical={this.state.snackbarVertical}
               snackbarHorizontal={this.state.snackbarHorizontal}
+              snackbarUserDoesNotExist={this.state.snackbarUserDoesNotExist}
             />
             <CssBaseline>
               <SignInOut

--- a/client/src/components/Snackbar/MainSnackbar.jsx
+++ b/client/src/components/Snackbar/MainSnackbar.jsx
@@ -25,7 +25,7 @@ const styles1 = theme => ({
 });
 
 const MySnackbarContentWrapper = withStyles(styles1)(MySnackbarContent);
-
+// snackbarUserDoesNotExist
 
 const MainSnackbar = (props) => {
   return (
@@ -50,14 +50,29 @@ const MainSnackbar = (props) => {
             vertical: props.snackbarVertical,
             horizontal: props.snackbarHorizontal
           }}
-          open={props.snackbarOpenError}
+          open={props.snackbarPasswordMismatch}
           onClose={props.handleSnackbarClose}
           autoHideDuration={2000}
         >
           <MySnackbarContentWrapper
             onClose={props.handleSnackbarClose}
             variant="error"
-            message="Incorrect Username/Password"
+            message="Password does not match"
+          />
+        </Snackbar>
+        <Snackbar
+          anchorOrigin={{
+            vertical: props.snackbarVertical,
+            horizontal: props.snackbarHorizontal
+          }}
+          open={props.snackbarUserDoesNotExist}
+          onClose={props.handleSnackbarClose}
+          autoHideDuration={2000}
+        >
+          <MySnackbarContentWrapper
+            onClose={props.handleSnackbarClose}
+            variant="error"
+            message="User does not exist"
           />
         </Snackbar>
         <Snackbar

--- a/controllers/login.js
+++ b/controllers/login.js
@@ -13,7 +13,7 @@ const login = (req, res, next) => {
   )
     .then((user) => {
       if (!user) {
-        res.status(422).json({"error": "User does not exist"})
+        res.status(423).json({"error": "User does not exist"})
         return
       }
       bcrypt.compare(req.body.password, user.password, (err, hashMatch) => {


### PR DESCRIPTION
# Description
Now when a user logs in, error messages differentiate between if "User doesn't exist" vs "Incorrect password"
Also add Creative Commons licence icon and link to readme for images used in this project.

Fixes # (issue)

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Change status
- [x] Complete, tested, ready to review and merge

# How Has This Been Tested?

Tested in Chrome Dev tools by trying to login with a user that doesn't exist and with a user that does exist but with the wrong password

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts
