### PR TITLE
apparently Heroku doesn't like nodmon anymore

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,6 @@
   },
   "scripts": {
     "test": "mocha",
-    "start": "nodemon server.js"
+    "start": "node server.js"
   }
 }


### PR DESCRIPTION
We have had our start sccript as "start": "nodemon server.js"  ever since we first deployed this project but, no Heroku's build process is fail because of it. So I'm switching it back to "start": "node server.js" and redeploying

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Change status

- [x] Complete, tested, ready to review and merge
- [ ] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback

